### PR TITLE
Change ERROR to WARNING when side ratio >= 3 in runConfig.sh.

### DIFF
--- a/Run/runConfig.sh_template
+++ b/Run/runConfig.sh_template
@@ -281,8 +281,7 @@ fi
 domain_ratio1=$(( $NX*6/$NY )) 
 domain_ratio2=$(( $NY/$NX/6 ))
 if [[ ${domain_ratio1} -ge 3 || ${domain_ratio2} -ge 3 ]] ; then
-    echo "ERROR: Change NX and NY such that NX x NY/6 is more square (side ratio < 3)"
-    exit 1
+    echo "WARNING: Change NX and NY such that NX x NY/6 is more square (side ratio < 3)"
 fi
 
 ## Check if restart file exists


### PR DESCRIPTION
With 18 total cores (e.g. EC2 `c5.9xlarge`), the side ratio has to be at least 3 (NX=3, NY=6).

The efficient is not that bad -- the advection time is reduced by 50%, compared to 6 cores:
- [run_2days_6core.log](https://github.com/geoschem/gchp/files/2761330/run_2days_6core.log)
- [run_2days_18core.log](https://github.com/geoschem/gchp/files/2761331/run_2days_18core.log)


