### PR TITLE
Fixes for gcc830

### DIFF
--- a/Shared/GMAO_pFIO/NetCDF4_FileFormatter.F90
+++ b/Shared/GMAO_pFIO/NetCDF4_FileFormatter.F90
@@ -870,7 +870,9 @@ contains
             call cf%add_attribute(trim(attr_name), str)
             deallocate(str)
          case default
-            _RETURN(_FAILURE)
+            ! Assume this will throw a failure later if the attribute is actually needed
+            call cf%add_attribute(trim(attr_name), 'MANGLED ATTRIBUTE')
+            !_RETURN(_FAILURE)
          end select
             
       end do

--- a/Shared/MAPL_Base/MAPL_AbstractRegridder.F90
+++ b/Shared/MAPL_Base/MAPL_AbstractRegridder.F90
@@ -183,7 +183,7 @@ contains
 
 
    subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL32
+      !use, intrinsic :: iso_fortran_env, only: REAL32
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:)
@@ -204,7 +204,7 @@ contains
 
 
    subroutine regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL64
+      !use, intrinsic :: iso_fortran_env, only: REAL64
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:)
@@ -224,7 +224,7 @@ contains
    end subroutine regrid_vector_2d_real64
 
    subroutine regrid_vector_3d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL32
+      !use, intrinsic :: iso_fortran_env, only: REAL32
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:,:)
@@ -246,7 +246,7 @@ contains
 
 
    subroutine regrid_vector_3d_real64(this, u_in, v_in, u_out, v_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL64
+      !use, intrinsic :: iso_fortran_env, only: REAL64
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:,:)
@@ -507,7 +507,7 @@ contains
    ! Begin - transpose interfaces
    
    subroutine transpose_regrid_scalar_2d_real32(this, q_in, q_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL32
+      !use, intrinsic :: iso_fortran_env, only: REAL32
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: q_in(:,:)
       real(kind=REAL32), intent(out) :: q_out(:,:)
@@ -523,7 +523,7 @@ contains
 
 
    subroutine transpose_regrid_scalar_2d_real64(this, q_in, q_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL64
+      !use, intrinsic :: iso_fortran_env, only: REAL64
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: q_in(:,:)
       real(kind=REAL64), intent(out) :: q_out(:,:)
@@ -539,7 +539,7 @@ contains
 
    
    subroutine transpose_regrid_scalar_3d_real32(this, q_in, q_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL32
+      !use, intrinsic :: iso_fortran_env, only: REAL32
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: q_in(:,:,:)
       real(kind=REAL32), intent(out) :: q_out(:,:,:)
@@ -556,7 +556,7 @@ contains
 
 
    subroutine transpose_regrid_scalar_3d_real64(this, q_in, q_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL64
+      !use, intrinsic :: iso_fortran_env, only: REAL64
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: q_in(:,:,:)
       real(kind=REAL64), intent(out) :: q_out(:,:,:)
@@ -573,7 +573,7 @@ contains
 
    
    subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL32
+      !use, intrinsic :: iso_fortran_env, only: REAL32
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:)
@@ -597,7 +597,7 @@ contains
 
 
    subroutine transpose_regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL64
+      !use, intrinsic :: iso_fortran_env, only: REAL64
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:)
@@ -621,7 +621,7 @@ contains
 
 
    subroutine transpose_regrid_vector_3d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL32
+      !use, intrinsic :: iso_fortran_env, only: REAL32
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:,:)
@@ -646,7 +646,7 @@ contains
 
 
    subroutine transpose_regrid_vector_3d_real64(this, u_in, v_in, u_out, v_out, rc)
-      use, intrinsic :: iso_fortran_env, only: REAL64
+      !use, intrinsic :: iso_fortran_env, only: REAL64
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:,:)
@@ -704,7 +704,7 @@ contains
          case (ESMF_TYPEKIND_R4%dkind)
 
             block
-              use, intrinsic :: iso_fortran_env, only: REAL32
+              !use, intrinsic :: iso_fortran_env, only: REAL32
               real(REAL32), pointer :: q_in(:,:), q_out(:,:)
               
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
@@ -718,7 +718,7 @@ contains
          case (ESMF_TYPEKIND_R8%dkind)
 
             block
-              use, intrinsic :: iso_fortran_env, only: REAL64
+              !use, intrinsic :: iso_fortran_env, only: REAL64
               real(REAL64), pointer :: q_in(:,:), q_out(:,:)
               
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
@@ -738,7 +738,7 @@ contains
          select case (typekind_in%dkind)
          case (ESMF_TYPEKIND_R4%dkind)
             block
-              use, intrinsic :: iso_fortran_env, only: REAL32
+              !use, intrinsic :: iso_fortran_env, only: REAL32
               real(REAL32), pointer :: q_in(:,:,:), q_out(:,:,:)
 
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
@@ -753,7 +753,7 @@ contains
          case (ESMF_TYPEKIND_R8%dkind)
 
             block
-              use, intrinsic :: iso_fortran_env, only: REAL64
+              !use, intrinsic :: iso_fortran_env, only: REAL64
               real(REAL64), pointer :: q_in(:,:,:), q_out(:,:,:)
 
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
@@ -822,7 +822,7 @@ contains
          case (ESMF_TYPEKIND_R4%dkind)
 
             block
-              use, intrinsic :: iso_fortran_env, only: REAL32
+              !use, intrinsic :: iso_fortran_env, only: REAL32
               real(REAL32), pointer :: u_in(:,:), v_in(:,:)
               real(REAL32), pointer :: u_out(:,:), v_out(:,:)
               
@@ -841,7 +841,7 @@ contains
          case (ESMF_TYPEKIND_R8%dkind)
 
             block
-              use, intrinsic :: iso_fortran_env, only: REAL64
+              !use, intrinsic :: iso_fortran_env, only: REAL64
               real(REAL64), pointer :: u_in(:,:), v_in(:,:)
               real(REAL64), pointer :: u_out(:,:), v_out(:,:)
               
@@ -866,7 +866,7 @@ contains
          select case (typekind_in(1)%dkind)
          case (ESMF_TYPEKIND_R4%dkind)
             block
-              use, intrinsic :: iso_fortran_env, only: REAL32
+              !use, intrinsic :: iso_fortran_env, only: REAL32
               real(REAL32), pointer :: u_in(:,:,:), v_in(:,:,:)
               real(REAL32), pointer :: u_out(:,:,:), v_out(:,:,:)
               
@@ -885,7 +885,7 @@ contains
          case (ESMF_TYPEKIND_R8%dkind)
 
             block
-              use, intrinsic :: iso_fortran_env, only: REAL64
+              !use, intrinsic :: iso_fortran_env, only: REAL64
               real(REAL64), pointer :: u_in(:,:,:), v_in(:,:,:)
               real(REAL64), pointer :: u_out(:,:,:), v_out(:,:,:)
               


### PR DESCRIPTION
Two fixes. The first is general; allowing NetCDF files which have a bad attribute (specifically, 
something is wrong with the datatype) to still be processed, assuming that if the attribute
is needed then it will cause issues down the line. The second fix is apparently needed for
certain version of the GNU compiler suite; a "use, intrinsic" statement can't be used for the
same variable at both the module and subroutine level.