### PR TITLE
Support Intel-MPI for both ifort and gfortran (allow ESMF_COMM=intelmpi)

### DIFF
--- a/ESMF/build_config/Linux.gfortran.default/build_rules.mk
+++ b/ESMF/build_config/Linux.gfortran.default/build_rules.mk
@@ -65,6 +65,13 @@ ESMF_CXXLINKLIBS       += $(shell $(ESMF_DIR)/scripts/libs.mvapich2f90)
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
 ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
 else
+ifeq ($(ESMF_COMM),intelmpi)
+# IntelMPI -------------------------------------------------
+ESMF_F90DEFAULT         = mpifort
+ESMF_CXXDEFAULT         = mpicxx
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
 ifeq ($(ESMF_COMM),lam)
 # LAM (assumed to be built with gfortran) -----------------------
 ESMF_CXXCOMPILECPPFLAGS+= -DESMF_NO_SIGUSR2
@@ -98,6 +105,7 @@ ifeq ($(ESMF_COMM),user)
 # User specified flags -------------------------------------
 else
 $(error Invalid ESMF_COMM setting: $(ESMF_COMM))
+endif
 endif
 endif
 endif

--- a/GIGC.mk
+++ b/GIGC.mk
@@ -65,7 +65,7 @@ else ifeq ($(ESMF_COMM),mpich2)
    MPI_LIB       := -L$(dir $(shell which mpif90))../lib64 -lmpich -lmpichf90
 else ifeq ($(ESMF_COMM),intelmpi)
    # %%%%% Intel MPI %%%%%
-   MPI_LIB       := -L$(dir $(shell which mpif90))../release/lib -lmpi
+   MPI_LIB       := -L$(dir $(shell which mpif90))../lib/release -lmpi
 else ifeq ($(ESMF_COMM),mpi)
    # %%%%% Generic MPI (works for SGI) %%%%%
    MPI_LIB       := -L$(dir $(shell which mpif90))../lib -lmpi -lmpi++

--- a/GIGC.mk
+++ b/GIGC.mk
@@ -63,6 +63,9 @@ else ifeq ($(ESMF_COMM),mpich)
 else ifeq ($(ESMF_COMM),mpich2)
    # %%%%% MPICH %%%%% 
    MPI_LIB       := -L$(dir $(shell which mpif90))../lib64 -lmpich -lmpichf90
+else ifeq ($(ESMF_COMM),intelmpi)
+   # %%%%% Intel MPI %%%%%
+   MPI_LIB       := -L$(dir $(shell which mpif90))../release/lib -lmpi
 else ifeq ($(ESMF_COMM),mpi)
    # %%%%% Generic MPI (works for SGI) %%%%%
    MPI_LIB       := -L$(dir $(shell which mpif90))../lib -lmpi -lmpi++

--- a/Shared/Config/ESMA_base.mk
+++ b/Shared/Config/ESMA_base.mk
@@ -230,6 +230,9 @@ LIB_ESMF := $(DIR_ESMF)/$(ARCH)/lib/libesmf.so
            INC_MPI := $(shell mpif90 --showme:incdirs)
            LIB_MPI := $(shell mpif90 --showme:link)
            LIB_MPI += $(shell mpicxx --showme:link)
+        else ifeq ($(ESMF_COMM),intelmpi)
+           INC_MPI := $(MPI_ROOT)/include
+           LIB_MPI := -L$(MPI_ROOT)/lib/release -lmpi
         else ifeq ($(ESMF_COMM),mpi)
            # Generic MPI
            INC_MPI := $(MPI_ROOT)/include


### PR DESCRIPTION
I have to use Intel MPI on AWS due to https://github.com/aws/aws-parallelcluster/issues/1143#issuecomment-528057160. Just successfully built 12.3.2 with Intel MPI (with both ifort and gfortran). Need to allow `ESMF_COMM=intelmpi` following [Expanding MPI Options](http://wiki.seas.harvard.edu/geos-chem/index.php/Setting_Up_the_GCHP_Environment#Expanding_MPI_Options_.28Advanced.29) in GCHP doc.

Adding this option to the top-level `GIGC.mk` seems quite natural, because`intelmpi` is already defined in files like `Linux.intel.default/build_rules.mk`:
https://github.com/geoschem/gchp/blob/305a133c749c18b1aa96d80bff4431fa6e77e92e/ESMF/build_config/Linux.intel.default/build_rules.mk#L67-L72

## Notes

### compiler command

Unlike the `mpiifort`/`mpiicpc` in `Linux.intel.default/build_rules.mk`, I use `mpifort`/`mpicxx` in `Linux.gfortran.default/build_rules.mk`. In Intel-MPI, `mpifort` wraps `gfortran`, while `mpiifort` wraps `ifort`: https://software.intel.com/en-us/mpi-developer-guide-linux-compilers-support.
(Can also force `mpifort` to wrap `ifort` by setting `I_MPI_CC=ifort`: https://software.intel.com/en-us/mpi-developer-reference-windows-compilation-environment-variables; but `mpiifort` always points to `ifort` regardless)

### MPI path

Intel-MPI puts `libmpi.so` inside `lib/release` instead of `lib`:

```console
$ spack install intel-mpi
$ cd $(spack location -i intel-mpi)/compilers_and_libraries/linux/mpi/intel64/lib/
$ ls
debug         libmpicxx.so.12      libmpifort.so         libmpi_ilp64.a       libmpijava.so      release
debug_mt      libmpicxx.so.12.0    libmpifort.so.12      libmpi_ilp64.so      libmpijava.so.1    release_mt
libmpicxx.a   libmpicxx.so.12.0.0  libmpifort.so.12.0    libmpi_ilp64.so.4    libmpijava.so.1.0
libmpicxx.so  libmpifort.a         libmpifort.so.12.0.0  libmpi_ilp64.so.4.1  mpi.jar
$ ls release
libmpi.a  libmpi.dbg  libmpi.so  libmpi.so.12  libmpi.so.12.0  libmpi.so.12.0.0
```

With Spack, the proper `$MPI_ROOT` should be 
```
export MPI_ROOT=$(spack location -i intel-mpi)/compilers_and_libraries/linux/mpi/intel64
```

## Question

I am curious why it is necessary to define build rules for every MPI instead of just calling the `mpicc`/`mpifort` wrapper? Just historical reasons? GCHP's build system is so fragile, largely due to those compiler/MPI-specific configs. Those high-level MPI wrappers are exactly invented to solve this problem....
