### PR TITLE
Implement python-based alternative to bc for runConfig.sh

### DIFF
--- a/Run/runConfig.sh.template
+++ b/Run/runConfig.sh.template
@@ -291,8 +291,21 @@ fi
 #### If on, auto-calculate NX and NY to maximize squareness of core regions
 if [[ ${NXNY_AUTO} == 'ON' ]]; then
    Z=$(( ${NUM_NODES}*${NUM_CORES_PER_NODE}/6 ))
-   SQRT=$(echo "sqrt (${Z})" | bc -l)  
-   N=$(echo $SQRT | awk '{print int($1+0.999)}')
+   # Use "bash calculator" if available; Python if not; fail otherwise
+   which bc &> /dev/null; bc_ok=$?
+   which python &> /dev/null; py_ok=$?
+   if [[ $bc_ok -eq 0 ]]; then
+      # Use bash calculator
+      SQRT=$(echo "sqrt (${Z})" | bc -l)  
+      N=$(echo $SQRT | awk '{print int($1+0.999)}')
+   elif [[ $py_ok -eq 0 ]]; then
+      # Use system Python
+      SQRT=$( python -c "import math; print(int(math.sqrt(${Z})))" )
+      N=$SQRT
+   else
+      echo "Cannot auto-determine NX and NY (need either bc or python available)"
+      exit 70
+   fi
    while [[ "${N}" > 0 ]]; do
       if (( ${Z} % ${N} == 0 )); then
          NX=${N}


### PR DESCRIPTION
Previously, setup would fail silently if the node did not have
bc ("bash calculator") installed when estimating NX and NY. Now,
if bc is not available, python will be used instead; and if
python is not found then an explicit error is thrown.

Signed-off-by: Sebastian D. Eastham <seastham@mit.edu>