### PR TITLE
Make intelgcc a valid ESMF_COMPILER option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ ifeq ($(ESMF_COMPILER),intel)
   MAJORVERSION     :=$(subst ., ,$(LONGVERSION))
   MAJORVERSION     :=$(firstword $(MAJORVERSION))
   MAJORVERSION     :=$(strip $(MAJORVERSION))
+else ifeq ($(ESMF_COMPILER),intelgcc)
+  INTELVERSIONTEXT :=$(shell ifort --version))
+  INTELVERSIONTEXT :=$(sort $(INTELVERSIONTEXT))
+  LONGVERSION      :=$(word 3, $(INTELVERSIONTEXT))
+  MAJORVERSION     :=$(subst ., ,$(LONGVERSION))
+  MAJORVERSION     :=$(firstword $(MAJORVERSION))
+  MAJORVERSION     :=$(strip $(MAJORVERSION))
 else ifeq ($(ESMF_COMPILER),gfortran)
   GNUVERSIONTEXT   :=$(shell gfortran -dumpversion))
   LONGVERSION      :=$(GNUVERSIONTEXT))
@@ -134,6 +141,8 @@ export ESMF_INSTALL_HEADERDIR=$(ESMF_DIR)/$(ARCH)/include
 
 # Other ESMF compilation settings
 ifeq ($(ESMF_COMPILER),intel)
+  export ESMF_F90COMPILEOPTS=-align all -fPIC -traceback 
+else ifeq ($(ESMF_COMPILER),intelgcc)
   export ESMF_F90COMPILEOPTS=-align all -fPIC -traceback 
 else ifeq ($(ESMF_COMPILER),gfortran)
   export ESMF_F90COMPILEOPTS=-falign-commons -fPIC -fbacktrace


### PR DESCRIPTION
We've been using "intel" as our ESMF_COMPILER, but that's designed for
situations where Intel compilers are being used for Fortran, C, and C++.
We are instead using Intel's Fortran compilers but GNU C and C++ compilers.
This is the cause of two issues:
a) Strange warnings in the build log about "unary operators"
b) Can't compile ESMF with "ESMF_BOPT=g" (debug flags)
This is easy to fix by setting ESMF_COMPILER=intelgcc, but the Makefiles
for GCHP and GCC need to be modified to allow for this. This commit
does that job for GCHP.

Signed-off-by: Sebastian D. Eastham <seastham@mit.edu>