### PR TITLE
Change makefile headers for using intel MPI

### DIFF
--- a/ESMF/build_config/Linux.intel.default/build_rules.mk
+++ b/ESMF/build_config/Linux.intel.default/build_rules.mk
@@ -87,6 +87,13 @@ ESMF_CXXDEFAULT         = mpiicpc
 ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
 ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
 else
+ifeq ($(ESMF_COMM),intel)
+# IntelMPI -------------------------------------------------
+ESMF_F90DEFAULT         = mpiifort
+ESMF_CXXDEFAULT         = mpiicpc
+ESMF_MPIRUNDEFAULT      = mpirun $(ESMF_MPILAUNCHOPTIONS)
+ESMF_MPIMPMDRUNDEFAULT  = mpiexec $(ESMF_MPILAUNCHOPTIONS)
+else
 ifeq ($(ESMF_COMM),scalimpi)
 # scaliMPI -------------------------------------------------
 ESMF_F90DEFAULT         = mpif90
@@ -125,6 +132,7 @@ ifeq ($(ESMF_COMM),user)
 # User specified flags -------------------------------------
 else
 $(error Invalid ESMF_COMM setting: $(ESMF_COMM))
+endif
 endif
 endif
 endif

--- a/GIGC.mk
+++ b/GIGC.mk
@@ -64,6 +64,9 @@ else ifeq ($(ESMF_COMM),mpich)
 else ifeq ($(ESMF_COMM),mpich2)
    # %%%%% MPICH %%%%% 
    MPI_LIB       := -L$(dir $(shell which mpif90))../lib64 -lmpich -lmpichf90
+else ifeq ($(ESMF_COMM),intel)
+   # %%%%% INTEL MPI %%%%%
+   MPI_LIB       := -L$(dir $(shell which mpiifort))/lib -lmpi
 else ifeq ($(ESMF_COMM),mpi)
    # %%%%% Generic MPI (works for SGI) %%%%%
    MPI_LIB       := -L$(dir $(shell which mpif90))../lib -lmpi -lmpi++

--- a/Shared/Config/mpi.mk
+++ b/Shared/Config/mpi.mk
@@ -82,6 +82,11 @@
      INC_MPI := $(shell mpif90 --showme:incdirs)
      LIB_MPI := $(shell mpif90 --showme:link)
      LIB_MPI += $(shell mpicxx --showme:link)
+  else ifeq ($(ESMF_COMM),intel)
+     FC := mpiifort
+     INC_MPI := $(MPI_ROOT)/include64
+     LIB_MPI := -L$(MPI_ROOT)/lib64 -lmpifort -lmpi # Intel MPI
+     LIB_MPI_OMP := -L$(MPI_ROOT)/lib64 -lmpifort -lmpi_mt # Intel MPI
   else ifeq ($(ESMF_COMM),mpi)
      # Generic MPI
      INC_MPI := $(MPI_ROOT)/include


### PR DESCRIPTION
We compiled GCHP v12.8.2 with Intel compiler version of Intel MPI. 
These changes together with soft-linking mpifort to mpiifort (only needed when compiling GC-classic part of codes) work for us. [compile.log](https://github.com/geoschem/gchp/files/4803445/compile_intelmpi_20200619.log) file is attached.

PR opened for reference in #68 .